### PR TITLE
Original meshnet implementation uses strings.Contains() for checking …

### DIFF
--- a/daemon/grpcwire/grpcwire.go
+++ b/daemon/grpcwire/grpcwire.go
@@ -326,16 +326,16 @@ func CreateGRPCWireRemoteTriggered(wireDef *mpb.WireDef, stopC chan struct{}) (*
 		log.Infof("Error creating vEth pair (in:%s <--> out:%s).  Error-> %s", inIfNm, outIfNm, err)
 		return nil, err
 	}
-	locInf, err := net.InterfaceByName(hostEndVeth.LinkName)
+	locIface, err := net.InterfaceByName(hostEndVeth.LinkName)
 	if err != nil {
 		log.Fatalf("Could not get interface index for %s. error:%v", hostEndVeth.LinkName, err)
 		return nil, err
 	}
-	log.Infof("On Remote Trigger: Successfully created vEth pair (in(name):%s <--> out(name-index):%s:%d).", inIfNm, outIfNm, locInf.Index)
+	log.Infof("On Remote Trigger: Successfully created vEth pair (in(name):%s <--> out(name-index):%s:%d).", inIfNm, outIfNm, locIface.Index)
 	aWire := &GRPCWire{
 		UID: int(wireDef.LinkUid),
 
-		LocalNodeIfaceID:   int64(locInf.Index),
+		LocalNodeIfaceID:   int64(locIface.Index),
 		LocalNodeIfaceName: hostEndVeth.LinkName,
 		LocalPodIP:         wireDef.LocalPodIp,
 		LocalPodIfaceName:  wireDef.IntfNameInPod,

--- a/daemon/meshnet/handler.go
+++ b/daemon/meshnet/handler.go
@@ -282,15 +282,15 @@ func (m *Meshnet) AddGRPCWireLocal(ctx context.Context, wireDef *mpb.WireDef) (*
 	aWire := grpcwire.GRPCWire{
 		UID: int(wireDef.LinkUid),
 
-		LocalNodeIntfID: int64(locInf.Index),
-		LocalNodeIntfNm: wireDef.VethNameLocalHost,
-		LocalPodIP:      wireDef.LocalPodIp,
-		LocalPodIntfNm:  wireDef.IntfNameInPod,
-		LocalPodNm:      wireDef.LocalPodName,
-		LocalPodNetNS:   wireDef.LocalPodNetNs,
+		LocalNodeIfaceID:   int64(locInf.Index),
+		LocalNodeIfaceName: wireDef.VethNameLocalHost,
+		LocalPodIP:         wireDef.LocalPodIp,
+		LocalPodIfaceName:  wireDef.IntfNameInPod,
+		LocalPodName:       wireDef.LocalPodName,
+		LocalPodNetNS:      wireDef.LocalPodNetNs,
 
-		PeerIntfID: wireDef.PeerIntfId,
-		PeerPodIP:  wireDef.PeerIp,
+		PeerIfaceID: wireDef.PeerIntfId,
+		PeerPodIP:   wireDef.PeerIp,
 
 		Originator:   grpcwire.HOST_CREATED_WIRE,
 		OriginatorIP: "unknown", /*+++todo retrieve host ip and set it here. Needed only for debugging */
@@ -341,10 +341,10 @@ func (m *Meshnet) AddGRPCWireRemote(ctx context.Context, wireDef *mpb.WireDef) (
 		// TODO: handle error here
 		go grpcwire.RecvFrmLocalPodThread(wire)
 
-		return &mpb.WireCreateResponse{Response: true, PeerIntfId: wire.LocalNodeIntfID}, nil
+		return &mpb.WireCreateResponse{Response: true, PeerIntfId: wire.LocalNodeIfaceID}, nil
 	}
 	log.Errorf("AddWireRemote err : %v", err)
-	return &mpb.WireCreateResponse{Response: false, PeerIntfId: wire.LocalNodeIntfID}, err
+	return &mpb.WireCreateResponse{Response: false, PeerIntfId: wire.LocalNodeIfaceID}, err
 }
 
 //---------------------------------------------------------------------------------------------------------------
@@ -359,5 +359,5 @@ func (m *Meshnet) GRPCWireExists(ctx context.Context, wireDef *mpb.WireDef) (*mp
 	if !ok || wire == nil {
 		return &mpb.WireCreateResponse{Response: false, PeerIntfId: 0}, nil
 	}
-	return &mpb.WireCreateResponse{Response: ok, PeerIntfId: wire.PeerIntfID}, nil
+	return &mpb.WireCreateResponse{Response: ok, PeerIntfId: wire.PeerIfaceID}, nil
 }

--- a/manifests/overlays/e2e/kustomization.yaml
+++ b/manifests/overlays/e2e/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: networkop/meshnet
-  newTag: 8a4c363-dirty
+  newTag: 63318a5-dirty
 resources:
 - ../../base/

--- a/manifests/overlays/grpc-link/kustomization.yaml
+++ b/manifests/overlays/grpc-link/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: networkop/meshnet
-  newTag: 8a4c363-dirty
+  newTag: 63318a5-dirty
 patches:
 - patch: |-
     - op: replace

--- a/plugin/grpcwires-plugin.go
+++ b/plugin/grpcwires-plugin.go
@@ -164,7 +164,7 @@ func CreatGRPCChan(link *mpb.Link, localPod *mpb.Pod, peerPod *mpb.Pod, localCli
 	}
 
 	log.Infof("Create GRPC wire: dialing remote node-->%s@%s", peerPod.Name, url)
-	creatResp, err := (remoteClient).AddGRPCWireRemote(*ctx, &wireDefRemot)
+	creatResp, err := remoteClient.AddGRPCWireRemote(*ctx, &wireDefRemot)
 	if err != nil {
 		return fmt.Errorf("failed to create grpc tunnel ar remote end:%s  err:%v", url, err)
 	} else if !creatResp.Response {
@@ -368,7 +368,7 @@ func CreatGRPCChan_new(link *mpb.Link, localPod *mpb.Pod, peerPod *mpb.Pod, loca
 	}
 
 	log.Infof("Create GRPC wire: dialing remote node-->%s@%s", peerPod.Name, url)
-	creatResp, err := (remoteClient).AddGRPCWireRemote(ctx, &wireDefRemot)
+	creatResp, err := remoteClient.AddGRPCWireRemote(ctx, &wireDefRemot)
 	if err != nil {
 		return fmt.Errorf("failed to create grpc tunnel ar remote end:%s  err:%v", url, err)
 	} else if !creatResp.Response {

--- a/plugin/meshnet.go
+++ b/plugin/meshnet.go
@@ -89,7 +89,7 @@ func getVxlanSource(nodeIP string) (string, string, error) {
 	}
 	nIP := net.ParseIP(nodeIP)
 	if nIP == nil {
-		return "", "", fmt.Errorf("parsing filed for meshnetd provided no HOST_IP address: %s", nodeIP)
+		return "", "", fmt.Errorf("parsing failed for meshnetd provided no HOST_IP address: %s", nodeIP)
 	}
 	ifaces, _ := net.Interfaces()
 	for _, i := range ifaces {


### PR DESCRIPTION
Original meshnet implementation uses strings.Contains() for checking  equality of ip addresses. This can give false results while comparing 10.10.10.11 & 10.10.10.1. It will declare both of these addresses to be equal. Fixing this. Additionally some variables are renamed.