### PR TITLE
Grpc link review comments

### DIFF
--- a/.github/workflows/ci-grpc.yml
+++ b/.github/workflows/ci-grpc.yml
@@ -1,0 +1,43 @@
+name: CI gRPC
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+      - uses: actions/checkout@v2
+      - run: make test
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build e2e test env
+        run: make up
+
+      - name: Build docker image
+        run: make docker
+
+      - name: Install meshnet with GRPC link
+        run: make grpc=1 install
+
+      - name: Run tests
+        run: make e2e
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,3 @@ jobs:
 
       - name: Run tests
         run: make e2e
-
-      - name: Uninstall meshnet with VXLAN link
-        run: make uninstall
-
-      - name: Install meshnet with GRPC link
-        run: make grpc=1 install
-
-      - name: Run tests
-        run: make e2e
-

--- a/daemon/cni/cni.go
+++ b/daemon/cni/cni.go
@@ -100,6 +100,13 @@ func saveInterNodeLinkConf() error {
 	return ioutil.WriteFile(interNodeLinkConf, []byte(os.Getenv("INTER_NODE_LINK_TYPE")), os.FileMode(06444))
 }
 
+func removeInterNodeLinkConf() error {
+	if err := os.Remove(interNodeLinkConf); err != nil {
+		return fmt.Errorf("failed to remove %s: %v", interNodeLinkConf, err)
+	}
+	return nil
+}
+
 // Init installs meshnet CNI configuration
 func Init() error {
 
@@ -130,5 +137,8 @@ func Init() error {
 func Cleanup() {
 	if err := os.Remove(meshnetCNIPath); err != nil {
 		log.Infof("Failed to remove file %s: %v", meshnetCNIPath, err)
+	}
+	if err := removeInterNodeLinkConf(); err != nil {
+		log.Infof("Failed to remove inter node link conf: %v", err)
 	}
 }

--- a/manifests/overlays/e2e/kustomization.yaml
+++ b/manifests/overlays/e2e/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: networkop/meshnet
-  newTag: 1e6d7eb-dirty
+  newTag: 9cd1b86-dirty
 resources:
 - ../../base/

--- a/manifests/overlays/grpc-link-e2e/kustomization.yaml
+++ b/manifests/overlays/grpc-link-e2e/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: networkop/meshnet
-  newTag: 1e6d7eb-dirty
+  newTag: 9cd1b86-dirty
 resources:
 - ../grpc-link/

--- a/plugin/meshnet.go
+++ b/plugin/meshnet.go
@@ -475,6 +475,8 @@ func SetInterNodeLinkType() {
 	b, err := os.ReadFile("/etc/cni/net.d/meshnet-inter-node-link-type")
 	if err != nil {
 		log.Warningf("Could not read iner node link type: %v", err)
+		// use the default value
+		return
 	}
 
 	interNodeLinkType = string(b)


### PR DESCRIPTION
- Provide separate CI jobs for VXLAN and GRPC
- Remove inter-node link conf as part of cleanup routine
- Default to VXLAN if reading content from inter-node link conf fails

P.S. The pre-existing cleanup code doesn't really get called upon uninstallation of meshnet-cni, and hence it doesn't actually cleanup plugin configuration afterwards.

```go
func main() {

	if err := cni.Init(); err != nil {
		log.Errorf("Failed to initialise CNI plugin: %v", err)
		os.Exit(1)
	}
	defer cni.Cleanup()
```