### PR TITLE
Improved logging and pod status check retry counts.  (#60)

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -6,7 +6,9 @@ import (
 	"strconv"
 
 	"github.com/networkop/meshnet-cni/daemon/cni"
+	"github.com/networkop/meshnet-cni/daemon/grpcwire"
 	"github.com/networkop/meshnet-cni/daemon/meshnet"
+	"github.com/networkop/meshnet-cni/daemon/vxlan"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -33,6 +35,10 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 		log.Debug("Verbose logging enabled")
 	}
+
+	meshnet.InitLogger()
+	grpcwire.InitLogger()
+	vxlan.InitLogger()
 
 	m, err := meshnet.New(meshnet.Config{
 		Port: grpcPort,

--- a/daemon/meshnet/meshnet.go
+++ b/daemon/meshnet/meshnet.go
@@ -39,15 +39,21 @@ type Meshnet struct {
 	lis     net.Listener
 }
 
+var mnetdLogger *log.Entry = nil
+
+func InitLogger() {
+	mnetdLogger = log.WithFields(log.Fields{"daemon": "meshnetd"})
+}
+
 func restConfig() (*rest.Config, error) {
-	log.Infof("Trying in-cluster configuration")
+	mnetdLogger.Infof("Trying in-cluster configuration")
 	rCfg, err := rest.InClusterConfig()
 	if err != nil {
 		kubecfg := filepath.Join(".kube", "config")
 		if home := homedir.HomeDir(); home != "" {
 			kubecfg = filepath.Join(home, kubecfg)
 		}
-		log.Infof("Falling back to kubeconfig: %q", kubecfg)
+		mnetdLogger.Infof("Falling back to kubeconfig: %q", kubecfg)
 		rCfg, err = clientcmd.BuildConfigFromFlags("", kubecfg)
 		if err != nil {
 			return nil, err
@@ -89,7 +95,7 @@ func New(cfg Config) (*Meshnet, error) {
 }
 
 func (m *Meshnet) Serve() error {
-	log.Infof("GRPC server has started on port: %d", m.config.Port)
+	mnetdLogger.Infof("GRPC server has started on port: %d", m.config.Port)
 	return m.s.Serve(m.lis)
 }
 


### PR DESCRIPTION
* added log

* build ok

* retry added on skip status check

* Revert "retry added on skip status check"

This reverts commit 80a8e6decf177b5e781ba90cdb826be8110096be.

* Retry added on skip status check

* incorporated comments

* stopped transferring large packet across nodes.

* enhanced log when pkt size exceeds mtu

* decoding for multi pkts added

* Fix seg violation

* format go mod

* fix typo

* Changed packet buffer size

* Fixed imagePullPolicy

* Clean up tags in overlays

* Added seperate logger for vrpc and vxlan overlays

* Updated Delete path logs

* Updated loggin in the sending path

* few log msg level changed. increased skip status retrieval counter to 10

* updating

* Removed unexpected image tag

Co-authored-by: manomugdha <manomugdha.biswas@keysight.com>
Co-authored-by: alexmasi <alexmasi@google.com>
Co-authored-by: Ashutosh Kumar <ashutshkumr@gmail.com>
Co-authored-by: manomugdha <91363038+manomugdha@users.noreply.github.com>